### PR TITLE
Fix missing account number (issue #6)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.3.1
 commit = True
 
 [bumpversion:file:setup.py]

--- a/reporter.py
+++ b/reporter.py
@@ -217,7 +217,11 @@ class Reporter:
         if not extra_params:
             extra_params = {}
 
-        command = f'[p=Reporter.properties, {cmd_type.capitalize()}.{command}]'
+        if self.account:
+            command = f'[p=Reporter.properties, a={self.account} {cmd_type.capitalize()}.{command}]'
+        else:
+            command = f'[p=Reporter.properties, {cmd_type.capitalize()}.{command}]'
+
         endpoint = ('https://reportingitc-reporter.apple.com'
                     f'/reportservice/{cmd_type}/v1')
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     extras_require={
         'dev': ['bumpversion'],
         'test': [
-            'pytest',
+            'pytest>=3.6',
             'faker',
             'responses',
             'pytest-responses',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='pytunes-reporter',
-    version='0.3.0',
+    version='0.3.1',
     description='Library to interact with iTunes Reporter API',
     long_description=long_description,
     long_description_content_type='text/x-rst',

--- a/test_reporter.py
+++ b/test_reporter.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote_plus
+
 import pytest
 import responses
 from faker import Factory
@@ -178,3 +180,15 @@ def test_error_handling():
     new_reporter = reporter.Reporter(user_id='asdf@asdf.com', password='12345')
     with pytest.raises(HTTPError):
         new_reporter.access_token
+
+
+# Fixing Issue #6
+def test_account_number_is_passed():
+    responses.add(
+        responses.POST,
+        sales_url,
+        status=200,
+    )
+    new_reporter = reporter.Reporter(user_id='asdf@asdf.com', account='654321', password='12345')
+    response = new_reporter._make_request('sales', 'getVendors', {})
+    assert quote_plus("a=654321") in response.request.body


### PR DESCRIPTION
As mentioned in issue #6 we are not actually passing the account variable to the API. If one is set, we should pass it in _make_request.