### PR TITLE
Fix string format for financial report commands

### DIFF
--- a/reporter.py
+++ b/reporter.py
@@ -184,8 +184,8 @@ class Reporter:
         credentials = {
             'accesstoken': self.access_token
         }
-        command = (f'getReport {vendor}, {region_code}, {report_type}, '
-                   f'{fiscal_year}, {fiscal_period}')
+        command = (f'getReport, {vendor},{region_code},{report_type},'
+                   f'{fiscal_year},{fiscal_period}')
 
         return self._process_gzip(self.make_request('finance', command,
                                                     credentials))


### PR DESCRIPTION
The command string for downloading financial reports should have the same format as command string for sales reports. Old version leads to HTTP 403 error.